### PR TITLE
fix: change compiler target to ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2022",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["ES2022"],
     "strict": true,
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
ES2022 is supported by min Node v18. This was forgotten when Node v16 support was removed.